### PR TITLE
Misc Fixes to Plugin

### DIFF
--- a/src/main/java/XbeLoader/XbeXbSymbolDatabaseAnalyzer.java
+++ b/src/main/java/XbeLoader/XbeXbSymbolDatabaseAnalyzer.java
@@ -92,6 +92,14 @@ public class XbeXbSymbolDatabaseAnalyzer extends AbstractAnalyzer {
 			return false;
 		}
 		String xbePath = program.getExecutablePath();
+		// HACK: Somehow GUI broke this yet headlessAnalyzer didn't...
+		// Ensure path does not erroneously begin with `/` before drive letter cause by Ghidra's end.
+		if (Platform.CURRENT_PLATFORM.getOperatingSystem() == OperatingSystem.WINDOWS) {
+			if (xbePath.charAt(0) == '/' && xbePath.charAt(1) != '/') {
+				xbePath = xbePath.substring(1).replace("/", "\\");
+			}
+		}
+		
 		List<String> cmd = new ArrayList<>();
 		cmd.add(toolPath);
 		cmd.add(xbePath);

--- a/src/main/java/XbeLoader/XbeXbSymbolDatabaseAnalyzer.java
+++ b/src/main/java/XbeLoader/XbeXbSymbolDatabaseAnalyzer.java
@@ -99,7 +99,6 @@ public class XbeXbSymbolDatabaseAnalyzer extends AbstractAnalyzer {
 		try {
 			Process exec = new ProcessBuilder().command(cmd).start();
 			BufferedReader output = new BufferedReader(new InputStreamReader(exec.getInputStream()));
-			exec.waitFor();
 
 			String line;
 			while ((line = output.readLine()) != null) {
@@ -111,6 +110,8 @@ public class XbeXbSymbolDatabaseAnalyzer extends AbstractAnalyzer {
 				String name = fullName.substring(libNameLength+2);
 				program.getSymbolTable().createLabel(address, name, getNamespace(program, lib), SourceType.ANALYSIS);
 			}
+			
+			exec.waitFor();
 		} catch (InterruptedException e) {
 			log.appendMsg("Failed to run " + toolExec);
 			return false;


### PR DESCRIPTION
Two fixes plugin require for Windows platform to work correctly are:
 * Fix buffer's stream being full and unable to flush into output buffer reader. Without this fix, Ghidra Xbe plugin will cause deadlock for XbSymbolDatabaseTool executable on Windows platform. (Not verified on other platforms.)
 * Ghidra 9.1.x has a bug for GUI version causing extra slash before drive letter when it's not supposed to. Yet somehow it doesn't affect opening xbe files. Headless version of analyzer does not have this problem.
   * This hack check if there is single forward slash before drive letter will enforce standard Windows' file path before attempt to use XbSymbolDatabaseTool exectuable. Although, it also check if 2nd character is not forward slash which is known for network drive usage.
   * I am not sure, it's possible Ghidra 2.x may have resolve the issue. I had not verified this and currently isn't compatible with Ghidra 2.x straight forward.