### PR TITLE
Skip trying to parse non-existent kernel thunk tables

### DIFF
--- a/src/main/java/XbeLoader/XbeLoader.java
+++ b/src/main/java/XbeLoader/XbeLoader.java
@@ -554,6 +554,10 @@ public class XbeLoader extends AbstractLibrarySupportLoader {
 		SymbolTable symbolTable = program.getSymbolTable();
 
 		Address address = kernelThunkTableAddr;
+		if (address.getOffset() == 0) {
+			// No kernel thunk table, skip processing step
+			return;
+		}
 
 		while (true) {
 			if (monitor.isCancelled()) {


### PR DESCRIPTION
This prevents a NullPointerException when trying to load xbes that have the kernel thunk table field set to zero. It only makes those files loadable, and takes no steps to help detect code that resolves kernel imports in other ways.