### PR TITLE
Add and Fix Segaboot's Xbe Support

### DIFF
--- a/src/main/java/XbeLoader/XbeLoader.java
+++ b/src/main/java/XbeLoader/XbeLoader.java
@@ -543,8 +543,11 @@ public class XbeLoader extends AbstractLibrarySupportLoader {
 	{
 		try {
 			// Read in section data and blank difference
-			byte[] data = input.readByteArray(off, (int)len);
-			data = Arrays.copyOf(data, (int)vlen);
+			byte[] data = new byte[(int)vlen];
+			System.arraycopy(input.readByteArray(off, (int)len), 0, data, 0, (int)len);
+			for (int i = (int)len; i < (int)vlen; i++) {
+				data[i] = 0;
+			}
 
 			// Create the memory block
 			MemoryBlock sec = api.createMemoryBlock(name, api.toAddr(vaddr), data, false);


### PR DESCRIPTION
I made an update to centralize retail, debug, and chihiro in one place for both entry point and thunk kernel. Which allow segaboot's xbes able to load.
close #28 

@GXTX found an issue with latest firmware inside SEGABOOT (combine of two xbes). After bypass null exception, I notice, "FLASHROM" did not appear in the section list. Main reason was due to createSection internal function cause an exception from `input.readByteArray` function for reading outside of physical size by using virtual length size. Hence the reason missing section did not appear and most likely cause other titles' last section not to appear. I made a 2nd commit to resolve the issue.
close #21