### PR TITLE
Update to Ghidra 10.0.1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,10 +2,11 @@
 
 export CORRETTO_ARCHIVE=amazon-corretto-15-x64-linux-jdk.tar.gz
 export CORRETTO_URL=https://corretto.aws/downloads/latest/${CORRETTO_ARCHIVE}
-export GHIDRA_VER=9.2.4_PUBLIC
-export GHIDRA_DATE=20210427
+export GHIDRA_VER_CORE=10.0.1
+export GHIDRA_VER=${GHIDRA_VER_CORE}_PUBLIC
+export GHIDRA_DATE=20210708
 export GHIDRA_ARCHIVE=ghidra_${GHIDRA_VER}_${GHIDRA_DATE}.zip
-export GHIDRA_URL=https://ghidra-sre.org/${GHIDRA_ARCHIVE}
+export GHIDRA_URL=https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${GHIDRA_VER_CORE}_build/${GHIDRA_ARCHIVE}
 export GRADLE_VER=6.8.2
 export GRADLE_ARCHIVE=gradle-${GRADLE_VER}-bin.zip
 export GRADLE_URL=https://services.gradle.org/distributions/${GRADLE_ARCHIVE}

--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,7 @@ declare -a URLS=(
 pushd /tmp
 
 echo "[*] Downloading files..."
-echo ${URLS[@]} | xargs -n 1 -P ${#URLS[@]} wget -nv
+echo ${URLS[@]} | xargs -n 1 -P ${#URLS[@]} wget -N -nv
 
 echo "[*] Extracting JDK..."
 tar --strip-components=1 --one-top-level=jdk -xf ${CORRETTO_ARCHIVE}


### PR DESCRIPTION
Updates the build script to build for Ghidra 10.0.1. Ghidra releases are now hosted on GitHub itself, so adjustments to the download path etc. were necessary.

Also fixes #8.