### PR TITLE
Update to Ghidra 10.0.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,28 +35,28 @@ jobs:
           path: dist
           if-no-files-found: error
 
-#   Test-Windows:
-#     needs: Build-Ubuntu
-#     runs-on: windows-latest
-#     env:
-#       POWERSHELL_TELEMETRY_OPTOUT: 1
-#     steps:
-#       - name: Download Artifacts
-#         uses: actions/download-artifact@v2
-#       - uses: actions/setup-java@v1
-#         with:
-#           java-version: ${{ needs.Build-Ubuntu.outputs.JAVA_VER }}
-#       - name: Install Ghidra
-#         run: |
-#           curl -SsfLO ${{ needs.Build-Ubuntu.outputs.GHIDRA_URL }}
-#           Expand-Archive -Path ${{ needs.Build-Ubuntu.outputs.GHIDRA_ARCHIVE }} -DestinationPath .
-#       - name: Install Extension
-#         run: Expand-Archive -Path dist\*ghidra-xbe.zip -DestinationPath ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\Ghidra\Extensions
-#       - name: Run Tests
-#         run: |
-#           ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\support\analyzeHeadless . test_project                             `
-#             -import ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\Ghidra\Extensions\ghidra-xbe\tests\xbefiles\triangle.xbe `
-#             -postScript ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\Ghidra\Extensions\ghidra-xbe\tests\test_load.py
+  Test-Windows:
+    needs: Build-Ubuntu
+    runs-on: windows-latest
+    env:
+      POWERSHELL_TELEMETRY_OPTOUT: 1
+    steps:
+      - name: Download Artifacts
+        uses: actions/download-artifact@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: ${{ needs.Build-Ubuntu.outputs.JAVA_VER }}
+      - name: Install Ghidra
+        run: |
+          curl -SsfLO ${{ needs.Build-Ubuntu.outputs.GHIDRA_URL }}
+          Expand-Archive -Path ${{ needs.Build-Ubuntu.outputs.GHIDRA_ARCHIVE }} -DestinationPath .
+      - name: Install Extension
+        run: Expand-Archive -Path dist\*ghidra-xbe.zip -DestinationPath ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\Ghidra\Extensions
+      - name: Run Tests
+        run: |
+          ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\support\analyzeHeadless . test_project                             `
+            -import ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\Ghidra\Extensions\ghidra-xbe\tests\xbefiles\triangle.xbe `
+            -postScript ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\Ghidra\Extensions\ghidra-xbe\tests\test_load.py
 
   Test-macOS:
     needs: Build-Ubuntu
@@ -81,7 +81,7 @@ jobs:
 
   Create-Release:
     if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [Build-Ubuntu, Test-macOS] # , Test-Windows
+    needs: [Build-Ubuntu, Test-Windows, Test-macOS]
     runs-on: ubuntu-latest
     steps:
       - name: Download Artifacts

--- a/build.sh
+++ b/build.sh
@@ -2,9 +2,9 @@
 
 export CORRETTO_ARCHIVE=amazon-corretto-15-x64-linux-jdk.tar.gz
 export CORRETTO_URL=https://corretto.aws/downloads/latest/${CORRETTO_ARCHIVE}
-export GHIDRA_VER_CORE=10.0.1
+export GHIDRA_VER_CORE=10.0.2
 export GHIDRA_VER=${GHIDRA_VER_CORE}_PUBLIC
-export GHIDRA_DATE=20210708
+export GHIDRA_DATE=20210804
 export GHIDRA_ARCHIVE=ghidra_${GHIDRA_VER}_${GHIDRA_DATE}.zip
 export GHIDRA_URL=https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${GHIDRA_VER_CORE}_build/${GHIDRA_ARCHIVE}
 export GRADLE_VER=6.8.2


### PR DESCRIPTION
This re-enables Windows CI and updates the build script to build for Ghidra 10.0.2, which was released two days ago.