### PR TITLE
Add execute permissions to Linux and macOS XbSymbolDatabase binaries

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -51,6 +51,10 @@ cp $XBSYMBOLDATABASE/LICENSE					os/osx64/XbSymbolDatabaseTool.LICENSE
 cp $XBSYMBOLDATABASE/win_x64/bin/XbSymbolDatabaseCLI.exe	os/win64/XbSymbolDatabaseTool.exe
 cp $XBSYMBOLDATABASE/LICENSE					os/win64/XbSymbolDatabaseTool.LICENSE
 
+# Add execute permissions to Linux and macOS XbSymbolDatabase binaries
+chmod +x os/linux64/XbSymbolDatabaseTool
+chmod +x os/osx64/XbSymbolDatabaseTool
+
 echo "[*] Building..."
 gradle -b build.gradle
 


### PR DESCRIPTION
The problem was described in #27. Turns out that it's [possible](https://serverfault.com/questions/585817/is-zip-archive-capable-of-storing-permissions) to store file system permissions in the zip archive, so I added execute permissions to Linux and macOS XbSymbolDatabase binaries.  

I also described the problem [in the corresponding issue in the Ghidra repo](https://github.com/NationalSecurityAgency/ghidra/issues/3448#issuecomment-928201385).  

Resolves #27