### PR TITLE
Fix out of bounds file reading when creating section

### DIFF
--- a/src/main/java/XbeLoader/XbeLoader.java
+++ b/src/main/java/XbeLoader/XbeLoader.java
@@ -524,10 +524,8 @@ public class XbeLoader extends AbstractLibrarySupportLoader {
 	{
 		try {
 			// Read in section data and blank difference
-			byte[] data = input.readByteArray(off, (int)vlen);
-			for (int i = (int)len; i < (int)vlen; i++) {
-				data[i] = 0;
-			}
+			byte[] data = input.readByteArray(off, (int)len);
+			data = Arrays.copyOf(data, (int)vlen);
 
 			// Create the memory block
 			MemoryBlock sec = api.createMemoryBlock(name, api.toAddr(vaddr), data, false);


### PR DESCRIPTION
Fixes #21

The issue was that the code tried to read from the file using the virtual size of the section, which was larger than the size in the file. This also caused the section to not get created properly.
The change fixes the read, and uses `Arrays.copyOf` to zero-extend the array up to the virtual size. `Arrays.copyOf` is available in Java 7, so it doesn't raise Ghidra's version requirements.