### PR TITLE
Correctly set write permission for sections

### DIFF
--- a/src/main/java/XbeLoader/XbeLoader.java
+++ b/src/main/java/XbeLoader/XbeLoader.java
@@ -492,7 +492,7 @@ public class XbeLoader extends AbstractLibrarySupportLoader {
 		reader.setPointerIndex(0);
 		createSection(api, "headers", reader,
 				header.baseAddr, header.imageHeaderSize,
-				0, header.imageHeaderSize, false);
+				0, header.imageHeaderSize, false, false);
 
 		// Read sections headers
 		reader.setPointerIndex(header.sectionHeadersAddr - header.baseAddr);
@@ -506,7 +506,8 @@ public class XbeLoader extends AbstractLibrarySupportLoader {
 			// Read section data
 			createSection(api, name, reader,
 					secHdr.virtualAddr, secHdr.virtualSize,
-					secHdr.rawAddr, secHdr.rawSize, (secHdr.flags & secHdr.FLAG_EXECUTABLE) != 0);
+					secHdr.rawAddr, secHdr.rawSize, (secHdr.flags & secHdr.FLAG_WRITABLE) != 0,
+					(secHdr.flags & secHdr.FLAG_EXECUTABLE) != 0);
 		}
 
 		// Process imports
@@ -520,7 +521,7 @@ public class XbeLoader extends AbstractLibrarySupportLoader {
 		processImports(program, monitor, log);
 	}
 
-	private void createSection(FlatProgramAPI api, String name, BinaryReader input, long vaddr, long vlen, long off, long len, boolean exec)
+	private void createSection(FlatProgramAPI api, String name, BinaryReader input, long vaddr, long vlen, long off, long len, boolean write, boolean exec)
 	{
 		try {
 			// Read in section data and blank difference
@@ -533,7 +534,7 @@ public class XbeLoader extends AbstractLibrarySupportLoader {
 			MemoryBlock sec = api.createMemoryBlock(name, api.toAddr(vaddr), data, false);
 			sec.setExecute(exec);
 			sec.setRead(true);
-			sec.setWrite(true);
+			sec.setWrite(write);
 		} catch (Exception e) {
 			Msg.error(this, e.getMessage());
 		}


### PR DESCRIPTION
The loader was always setting the writable flag, no matter whether `FLAG_WRITABLE` was set or not. Before & after screenshots of the hello sample below (`.data` is missing in the second one due to #21).


![Screenshot_20211001_045109](https://user-images.githubusercontent.com/1339483/135558981-1668a2ab-9969-4d2f-b1b3-78307c40ccb2.png)
![Screenshot_20211001_045859](https://user-images.githubusercontent.com/1339483/135558993-70e48222-7429-43fb-97dc-34428fe6c80d.png)


