### PR TITLE
Fix loading the XBE certificate header from an incorrect offset

### DIFF
--- a/src/main/java/XbeLoader/XbeImageHeader.java
+++ b/src/main/java/XbeLoader/XbeImageHeader.java
@@ -102,7 +102,7 @@ public class XbeImageHeader implements StructConverter {
 		if (imageHeaderSize >= 0x184)
 			debugInfo            = reader.readNextUnsignedInt();
 
-		reader.setPointerIndex(certificateAddr);
+		reader.setPointerIndex(certificateAddr - baseAddr);
 		certificateHeader = new XbeCertificateHeader(reader);
 	}
 


### PR DESCRIPTION
Found this while working on https://github.com/XboxDev/nxdk/pull/553
The code tries to read the certificate header by using its address, but the reader takes file offsets, so we need to convert the address by subtracting `baseAddr`.