### PR TITLE
Update to Ghidra 10.2

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -e
 
-export CORRETTO_ARCHIVE=amazon-corretto-15-x64-linux-jdk.tar.gz
+export CORRETTO_ARCHIVE=amazon-corretto-17-x64-linux-jdk.tar.gz
 export CORRETTO_URL=https://corretto.aws/downloads/latest/${CORRETTO_ARCHIVE}
-export GHIDRA_VER_CORE=10.1.5
+export GHIDRA_VER_CORE=10.2
 export GHIDRA_VER=${GHIDRA_VER_CORE}_PUBLIC
-export GHIDRA_DATE=20220726
+export GHIDRA_DATE=20221101
 export GHIDRA_ARCHIVE=ghidra_${GHIDRA_VER}_${GHIDRA_DATE}.zip
 export GHIDRA_URL=https://github.com/NationalSecurityAgency/ghidra/releases/download/Ghidra_${GHIDRA_VER_CORE}_build/${GHIDRA_ARCHIVE}
-export GRADLE_VER=6.8.2
+export GRADLE_VER=7.5.1
 export GRADLE_ARCHIVE=gradle-${GRADLE_VER}-bin.zip
 export GRADLE_URL=https://services.gradle.org/distributions/${GRADLE_ARCHIVE}
 export XBSYMBOLDATABASE_ARCHIVE=XbSymbolDatabase.zip


### PR DESCRIPTION
Also updates Gradle to `7.5.1` and Corretto to `17` due to Ghidra bumping up the required versions.