### PR TITLE
CI: Refactor for multi target ghidra

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,101 +13,161 @@ on:
       - '*.md'
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
-  Build-Ubuntu:
+  build:
     runs-on: ubuntu-latest
-    outputs:
-      GHIDRA_VER: ${{ steps.build.outputs.GHIDRA_VER }}
-      GHIDRA_ARCHIVE: ${{ steps.build.outputs.GHIDRA_ARCHIVE }}
-      GHIDRA_URL: ${{ steps.build.outputs.GHIDRA_URL }}
-      JAVA_VER: x # Latest
-      BUILD_TAG: ${{ steps.build.outputs.BUILD_TAG }}
+    strategy:
+      matrix:
+        # GHIDRA VERSIONS - Don't forget to also update the test job when updating this
+        ghidra:
+          - "12.0"
+          - "12.0.1"
+          - "12.0.2"
+          - "12.0.3"
+          - "12.0.4"
     steps:
-      - name: Clone Tree
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+
       - name: Install xsltproc
         run: |
           sudo apt-get -y update
           sudo apt-get -y install xsltproc
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: "21"
+          distribution: "temurin"
+
+      - name: Setup Ghidra
+        uses: antoniovazquezblanco/setup-ghidra@v2
+        with:
+          version: ${{ matrix.ghidra }}
+          auth_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v6
+        with:
+          gradle-version: "8.14.4"
+
+      - name: Download XbSymbolDatabase
+        run: |
+          wget -nv https://github.com/Cxbx-Reloaded/XbSymbolDatabase/releases/download/v3.1.160/XbSymbolDatabase.zip
+          unzip -qd XbSymbolDatabase XbSymbolDatabase.zip
+          rm XbSymbolDatabase.zip
+
+      - name: Copy XbSymbolDatabase binaries
+        run: |
+          cp XbSymbolDatabase/linux_x64/bin/XbSymbolDatabaseCLI   os/linux_x86_64/XbSymbolDatabaseCLI
+          cp XbSymbolDatabase/LICENSE                             os/linux_x86_64/XbSymbolDatabaseCLI.LICENSE
+          cp XbSymbolDatabase/macos_x64/bin/XbSymbolDatabaseCLI   os/mac_x86_64/XbSymbolDatabaseCLI
+          cp XbSymbolDatabase/LICENSE                             os/mac_x86_64/XbSymbolDatabaseCLI.LICENSE
+          cp XbSymbolDatabase/win_x64/bin/XbSymbolDatabaseCLI.exe os/win_x86_64/XbSymbolDatabaseCLI.exe
+          cp XbSymbolDatabase/LICENSE                             os/win_x86_64/XbSymbolDatabaseCLI.LICENSE
+          chmod +x os/linux_x86_64/XbSymbolDatabaseCLI
+          chmod +x os/mac_x86_64/XbSymbolDatabaseCLI
+          rm -rf XbSymbolDatabase
+
+      - name: Download xtlid database
+        run: wget -nv
+          https://github.com/XboxDev/xtlid/releases/download/v0.1.2/xtlid.xml
+
+      - name: Generate XTLID Java source
+        run: xsltproc -o src/main/java/XbeLoader/XbeXtlidDb.java xtlid2java.xslt xtlid.xml
+
       - name: Build
-        id: build
-        run: ./build.sh
-      - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        run: gradle buildExtension
+
+      - name: Install extension
+        run: |
+          cp dist/*ghidra-xbe.zip $GHIDRA_INSTALL_DIR/Ghidra/Extensions/
+          cd $GHIDRA_INSTALL_DIR/Ghidra/Extensions
+          unzip *ghidra-xbe.zip
+
+      - name: Run tests
+        run: |
+          cd tests
+          $GHIDRA_INSTALL_DIR/support/analyzeHeadless . test_project \
+            -import xbefiles/triangle.xbe \
+            -postScript ./test_load.py
+          test -e TEST_PASS
+
+      - uses: actions/upload-artifact@v7
         with:
-          name: dist
+          name: ghidra-xbe_Ghidra_${{ matrix.ghidra }}
+          path: dist/*.zip
+
+  test:
+    needs: build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-latest, windows-latest ]
+        # GHIDRA VERSIONS - Only set to latest due to GHA rate limits
+        ghidra: [ "12.0.4" ]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: ghidra-xbe_Ghidra_${{ matrix.ghidra }}
           path: dist
-          if-no-files-found: error
 
-  Test-Windows:
-    needs: Build-Ubuntu
-    runs-on: windows-latest
-    env:
-      POWERSHELL_TELEMETRY_OPTOUT: 1
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v5
         with:
-          java-version: ${{ needs.Build-Ubuntu.outputs.JAVA_VER }}
-      - name: Install Ghidra
-        run: |
-          curl -SsfLO ${{ needs.Build-Ubuntu.outputs.GHIDRA_URL }}
-          Expand-Archive -Path ${{ needs.Build-Ubuntu.outputs.GHIDRA_ARCHIVE }} -DestinationPath .
-      - name: Install Extension
-        run: Expand-Archive -Path dist\*ghidra-xbe.zip -DestinationPath ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\Ghidra\Extensions
-      - name: Run Tests
-        run: |
-          ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\support\analyzeHeadless . test_project                             `
-            -import ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\Ghidra\Extensions\ghidra-xbe\tests\xbefiles\triangle.xbe `
-            -postScript ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}\Ghidra\Extensions\ghidra-xbe\tests\test_load.py
+          java-version: "21"
+          distribution: "temurin"
 
-  Test-macOS:
-    needs: Build-Ubuntu
-    runs-on: macos-latest
-    steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-      - uses: actions/setup-java@v1
+      - name: Setup Ghidra
+        uses: antoniovazquezblanco/setup-ghidra@v2
         with:
-          java-version: ${{ needs.Build-Ubuntu.outputs.JAVA_VER }}
-      - name: Install Ghidra
-        run: |
-          wget -nv ${{ needs.Build-Ubuntu.outputs.GHIDRA_URL }}
-          unzip ${{ needs.Build-Ubuntu.outputs.GHIDRA_ARCHIVE }}
-      - name: Install Extension
-        run: unzip dist/*ghidra-xbe.zip -d ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}/Ghidra/Extensions
-      - name: Run Tests
-        run: |
-          ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}/support/analyzeHeadless . test_project                             \
-            -import ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}/Ghidra/Extensions/ghidra-xbe/tests/xbefiles/triangle.xbe \
-            -postScript ghidra_${{ needs.Build-Ubuntu.outputs.GHIDRA_VER }}/Ghidra/Extensions/ghidra-xbe/tests/test_load.py
+          version: ${{ matrix.ghidra }}
+          auth_token: ${{ secrets.GITHUB_TOKEN }}
 
-  Create-Release:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
-    needs: [Build-Ubuntu, Test-Windows, Test-macOS]
+      - name: Install extension
+        shell: bash
+        run: |
+          cp dist/*ghidra-xbe.zip "$GHIDRA_INSTALL_DIR/Ghidra/Extensions/"
+          cd "$GHIDRA_INSTALL_DIR/Ghidra/Extensions"
+          unzip *ghidra-xbe.zip
+
+      - name: Run tests
+        shell: bash
+        run: |
+          cd tests
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            "$GHIDRA_INSTALL_DIR/support/analyzeHeadless.bat" . test_project -import xbefiles/triangle.xbe -postScript ./test_load.py
+          else
+            "$GHIDRA_INSTALL_DIR/support/analyzeHeadless" . test_project -import xbefiles/triangle.xbe -postScript ./test_load.py
+          fi
+          test -e TEST_PASS
+
+  release:
+    if: github.ref == 'refs/heads/master'
+    needs: [build, test]
     runs-on: ubuntu-latest
     steps:
-      - name: Download Artifacts
-        uses: actions/download-artifact@v4
-      - name: Get Package Info
-        id: pkg_info
-        working-directory: dist
-        run: echo "::set-output name=PKG_NAME::$(ls *ghidra-xbe.zip)"
-      - name: Create Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/download-artifact@v8
         with:
-          tag_name: ${{ needs.Build-Ubuntu.outputs.BUILD_TAG }}
-          release_name: ${{ needs.Build-Ubuntu.outputs.BUILD_TAG }}
-      - name: Upload Release Assets
-        uses: actions/upload-release-asset@v1
+          path: dist
+          merge-multiple: true
+
+      - name: Create tag
+        id: create_tag
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="build-$(date -u +%Y%m%d%H%M)"
+          gh api repos/${{ github.repository }}/git/refs \
+            -f sha=${{ github.sha }} \
+            -f ref=refs/tags/$TAG
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Upload to GitHub Releases
+        uses: softprops/action-gh-release@v3
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_name: ${{ steps.pkg_info.outputs.PKG_NAME }}
-          asset_path: dist/${{ steps.pkg_info.outputs.PKG_NAME }}
-          asset_content_type: application/zip
+          tag_name: ${{ steps.create_tag.outputs.tag }}
+          files: dist/*.zip


### PR DESCRIPTION
I've updated the CI flow to use the setup-ghidra action, similar to how we did it in [ghidra_psx_ldr](https://github.com/lab313ru/ghidra_psx_ldr).

I've taken care to match how you were running tests on all 3 target platforms, specifically because of the XbSymbolDatabase binaries.

I've marked the two areas to set the Ghidra versions with `# GHIDRA VERSIONS`
I opted to do every version of Ghidra 12.
I only run the tests against latest (12.0.4) because of rate limits with the amount of setup requests running against all does. 
It can still happen with the number of runners unfortunately - as you can see here https://github.com/dreamsyntax/ghidra-xbe/actions/runs/24856148177/job/72769728906.

Passing GITHUB_TOKEN to attempt to avoid that.

I verified each test does pass on 12.0 - 12.0.4 before opening this.

This makes the `build.sh` script redundant, but I left it in the repo incase people use it for local setups.
Also updated the current github actions versions.

The flow is:

1. Build plugin for all ghidra versions specified
2. Run tests on macos/windows/linux
3. Auto release all artifacts in the same `build-YYYYMMDDHHMM` format the old script did, whenever master is updated


Example successful workflow in master:
https://github.com/dreamsyntax/ghidra-xbe/actions/runs/24856148177

Example release artifacts (auto generated from above)
https://github.com/dreamsyntax/ghidra-xbe/releases


Lastly thank you for all the effort on this! I've been using this extension quite regularly lately and its been a great help!